### PR TITLE
Made source_get_offset return float to allow precise AL_SEC_OFFSET

### DIFF
--- a/mojoal.c
+++ b/mojoal.c
@@ -531,7 +531,7 @@ struct ALCcontext_struct
 };
 
 /* forward declarations */
-static int source_get_offset(ALsource *src, ALenum param);
+static float source_get_offset(ALsource *src, ALenum param);
 static void source_set_offset(ALsource *src, ALenum param, ALfloat value);
 
 /* the just_queued list is backwards. Add it to the queue in the correct order. */
@@ -3940,7 +3940,7 @@ static void source_pause(ALCcontext *ctx, const ALuint name)
     }
 }
 
-static int source_get_offset(ALsource *src, ALenum param)
+static float source_get_offset(ALsource *src, ALenum param)
 {
     int offset = 0;
     int framesize = sizeof(float);
@@ -3960,10 +3960,10 @@ static int source_get_offset(ALsource *src, ALenum param)
         offset = src->offset;
     }
     switch(param) {
-        case AL_SAMPLE_OFFSET: return offset / framesize; break;
-        case AL_SEC_OFFSET: return (offset / framesize) / freq; break;
-        case AL_BYTE_OFFSET: return offset; break;
-        default: return 0; break;
+        case AL_SAMPLE_OFFSET: return (float)offset / framesize; break;
+        case AL_SEC_OFFSET: return ((float)offset / framesize) / freq; break;
+        case AL_BYTE_OFFSET: return (float)offset; break;
+        default: return 0.0f; break;
     }
 }
 


### PR DESCRIPTION
Hello. I'm not an expert in OpenAL, but using your library I found that calling `alGetSourcef` with `AL_SEC_OFFSET` returns only second-precise values, although according to [specs](https://www.openal.org/documentation/openal-1.1-specification.pdf) it should be supporting fractional values too.

It looks like this small change is enough to fix it.

PS. `_alGetSourceiv` already converting the result value to int here, so that should stay correct:
https://github.com/icculus/mojoAL/blob/44bb6799215238986d12ffa1d85ee49f24a2ccad/mojoal.c#L3742