### PR TITLE
Fix source_get_offset() null-pointer access

### DIFF
--- a/mojoal.c
+++ b/mojoal.c
@@ -4207,7 +4207,7 @@ static float source_get_offset(ALsource *src, ALenum param)
             int proc_buf = SDL_AtomicGet(&src->buffer_queue_processed.num_items);
             offset = (proc_buf * item->buffer->len + src->offset);
         }
-    } else {
+    } else if (src->buffer) {
         framesize = (int) (src->buffer->channels * sizeof (float));
         freq = (int) src->buffer->frequency;
         offset = src->offset;


### PR DESCRIPTION
This fixes a case when AL_**_OFFSET parameters are retrieved from a Source which has no buffers attached yet.

Fixes #9