### PR TITLE
Compatibility fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.0.0)
 find_package(SDL2 REQUIRED)
 
 add_library(mojoal SHARED mojoal.c)
-target_include_directories(mojoal PRIVATE ${SDL2_INCLUDE_DIRS})
+target_include_directories(mojoal PRIVATE ${SDL2_INCLUDE_DIRS} AL)
 target_link_libraries(mojoal ${SDL2_LIBRARIES})
 
 macro(add_test_executable _NAME)

--- a/mojoal.c
+++ b/mojoal.c
@@ -20,8 +20,8 @@
   #define M_PI (3.14159265358979323846264338327950288)
 #endif
 
-#include "AL/al.h"
-#include "AL/alc.h"
+#include "al.h"
+#include "alc.h"
 #include "SDL.h"
 
 #ifdef __SSE__  /* if you are on x86 or x86-64, we assume you have SSE1 by now. */


### PR DESCRIPTION
Two small things:
The first commit fixes building with VS2008, which needs mojoal.c to be compiled in C++ mode. So no implicit void* -> any* casts.
For the include location change in the 2nd commit refer to https://github.com/AquariaOSE/Aquaria/pull/78#issuecomment-1067494664
Imho, it's also easier for users to just plop the two .h files into some include dir rather than require them to be available under some AL/-subdir...