### PR TITLE
implement ALC_FREQUENCY case in alcGetIntegerv

### DIFF
--- a/mojoal.c
+++ b/mojoal.c
@@ -2570,6 +2570,16 @@ static void _alcGetIntegerv(ALCdevice *device, const ALCenum param, const ALCsiz
             *values = OPENAL_VERSION_MINOR;
             return;
 
+        case ALC_FREQUENCY:
+            if (!device) {
+                *values = 0;
+                set_alc_error(device, ALC_INVALID_DEVICE);
+                return;
+            }
+
+            *values = device->frequency;
+            return;
+
         default: break;
     }
 


### PR DESCRIPTION
Hello,

This implements ALC_FREQUENCY in alcGetIntegerv so that user can do:

```c
ALCint sampleRate = -1;
alcGetIntegerv(device, ALC_FREQUENCY, 1, &sampleRate);
```

I would have done the same for ALC_REFRESH and ALC_SYNC but they are not actually implemented yet (L2119 "use these variables at some point")

Please let me know if anything is incorrect or missing.

Best