### PR TITLE
fix MSVC warning C4244, ALfloat <- double

### DIFF
--- a/mojoal.c
+++ b/mojoal.c
@@ -1254,7 +1254,7 @@ static void pitch_shift(ALsource *src, const ALbuffer *buffer, int numSampsToPro
             /* do windowing and re,im interleave */
             for (k = 0; k < pitch_framesize;k++) {
                 window = -.5*SDL_cos(2.*M_PI*(double)k/(double)pitch_framesize)+.5;
-                state->workspace[2*k] = (ALfloat) state->infifo[k] * window;
+                state->workspace[2*k] = (ALfloat) (state->infifo[k] * window);
                 state->workspace[2*k+1] = 0.0f;
             }
 


### PR DESCRIPTION
this is the only remaining warning, a parenthesis is needed because the cast takes priority and applies first and later the multiplication with window casts all to double, and then the result gets cast again to ALfloat when assigning.

(no need to merge, feel free to just add the missing parenthesis on main)