### PR TITLE
Fix potential infinite loop in mix_source_buffer() in case of uneven input buffer

### DIFF
--- a/mojoal.c
+++ b/mojoal.c
@@ -1432,12 +1432,15 @@ static ALboolean mix_source_buffer(ALCcontext *ctx, ALsource *src, BufferQueueIt
         if (src->stream) {  /* resampling? */
             int mixframes, mixlen, remainingmixframes;
             while ( (((mixlen = SDL_AudioStreamAvailable(src->stream)) / bufferframesize) < framesneeded) && (src->offset < buffer->len) ) {
-                const int framesput = (buffer->len - src->offset) / bufferframesize;
-                const int bytesput = SDL_min(framesput, 1024) * bufferframesize;
+                const int bytesleft = (buffer->len - src->offset);
+                /* workaround in case remains are less than bufferframesize */
+                const int framesput = (bytesleft + (bufferframesize - 1)) / bufferframesize;
+                const int bytesput = SDL_min(SDL_min(framesput, 1024) * bufferframesize, bytesleft);
                 FIXME("dynamically adjust frames here?");  /* we hardcode 1024 samples when opening the audio device, too. */
                 SDL_AudioStreamPut(src->stream, data, bytesput);
                 src->offset += bytesput;
-                data += bytesput / sizeof (float);
+                /* workaround in case remains are not evenly divided by sizeof (float) */
+                data += (bytesput + (sizeof (float) - 1)) / sizeof (float);
             }
 
             mixframes = SDL_min(mixlen / bufferframesize, framesneeded);


### PR DESCRIPTION
Fix #23

This is a hotfix that we've been using in our game engine for a while now, it covers a rare situation with badly formed input buffer, which I've described in the issue #23.

This fixes a potential infinite loop, which may occur in two cases:
1. If remaining data in the input is less than `bufferframesize`, in such case `bytesput` resulted in 0, and src->offset never advanced.
2. If remaining data's size is not evenly divided by sizeof(float), the data pointer again will not advance to the end.