### PR TITLE
Fix another infinite loop in mix_source_buffer(), case of uneven input

### DIFF
--- a/mojoal.c
+++ b/mojoal.c
@@ -1471,6 +1471,11 @@ static ALboolean mix_source_buffer(ALCcontext *ctx, ALsource *src, BufferQueueIt
             const int mixframes = SDL_min(framesneeded, framesavail);
             mix_buffer(src, buffer, src->panning, data, *stream, mixframes);
             src->offset += mixframes * bufferframesize;
+            /* workaround in case remains are less than bufferframesize:
+            in this case it's easier to just skip the remaining sample */
+            if ((src->offset < buffer->len) && ((buffer->len - src->offset) < bufferframesize)) {
+                src->offset = buffer->len;
+            }
             *len -= mixframes * deviceframesize;
             *stream += mixframes * ctx->device->channels;
         }


### PR DESCRIPTION
This fixes another potential infinite loop (first one was fixed by #31), which may occur if remaining data in the input is less than `bufferframesize`. There are seemingly two options here:
1. Skip the remainder.
2. Use a local temp buffer, copy the remainder over and fill necessary remaining bytes with zeroes, then pass it into mix_buffer() too.

I chose the first, as this ever affects only 1 last sample which, apparently, does not have all of the channels data filled, so this does not seem to be worth it.

On a separate note, I suspect that instead of these workarounds, mojoAL could fix the buffer length in alBufferData, clamping it to the multiple of framesize. But I dont know the program too well, so idk if adjusting buffer's "length" value in this case may lead to any bad consequences.
