### PR TITLE
Fix building on Windows

### DIFF
--- a/mojoal.c
+++ b/mojoal.c
@@ -289,7 +289,7 @@ static void ungrab_api_lock(void)
     rettype AL_APIENTRY fn params { rettype retval; grab_api_lock(); retval = _##fn args ; ungrab_api_lock(); return retval; }
 
 #define ENTRYPOINTVOID(fn,params,args) \
-    void fn AL_APIENTRY params { grab_api_lock(); _##fn args ; ungrab_api_lock(); }
+    void AL_APIENTRY fn params { grab_api_lock(); _##fn args ; ungrab_api_lock(); }
 
 
 static size_t simd_alignment = 0;


### PR DESCRIPTION
I don't think writing the call convention after the function name is valid C, and my compiler (32-bit gcc 15.2 from MinGW) doesn't like it either.

- [x] I confirm that I am the author of this code and release it to the MojoAL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").